### PR TITLE
Full translation and dynamic banners

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # osCommerce - Mercadopago Module (v2.2 - 2.3)
 ---
 *Available for Argentina, Brazil, Mexico and Venezuela*
-*Prueba de modificación"
 
 ## Installation:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # osCommerce - Mercadopago Module (v2.2 - 2.3)
 ---
 *Available for Argentina, Brazil, Mexico and Venezuela*
-
+*Prueba de modificación"
 
 ## Installation:
 

--- a/v2.3/admin/ext/modules/payment/mercadopago/activation.php
+++ b/v2.3/admin/ext/modules/payment/mercadopago/activation.php
@@ -12,7 +12,7 @@
 
 chdir('../../../../');
 require('includes/application_top.php');
-require('../includes/languages/' . $language . '/modules/payment/mercadopago.php');
+require('../' . DIR_WS_LANGUAGES . $language . '/modules/payment/mercadopago.php');
 require('../includes/modules/payment/mercadopago.php');
   
 $action = (isset($HTTP_GET_VARS['action']) ? $HTTP_GET_VARS['action'] : '');
@@ -95,13 +95,13 @@ $mp = new mercadopago;
       $methods = implode(",", $posts['methods']);
     }
 
-    $categories = $mp->GetCategories();
+    $categories = $mp->GetCategories($posts['country']);
 
     $html_categories  = '<select name="categories" style="width: 200px">';
 
     foreach ($categories as $category) {
 
-      $html_categories .=  '<option value="'. $category['id'] .'" id="'.$category["id"].'">'.$category["description"] .'</option>';
+      $html_categories .=  '<option value="'. $category['id'] .'" id="'.$category["id"].'">'.$category["name"] .'</option>';
       
     }
 

--- a/v2.3/includes/languages/english/modules/payment/mercadopago.php
+++ b/v2.3/includes/languages/english/modules/payment/mercadopago.php
@@ -33,5 +33,6 @@ define('MB_ACTIVATION_ACTIVATE_METHODS_TEXT', 'Check only the payment methods th
 
 define('MP_CHECKOUT_METHOD_TEXT_DESCRIPTION','Accepted payment methods');
 define('MP_CHECKOUT_TEXT_DESCRIPTION','Continue paying with MercadoPago');
+define('MP_CHECKOUT_ERROR','Error to get preference key, please contact the store owner');
 
 ?>

--- a/v2.3/includes/languages/english/modules/payment/mercadopago.php
+++ b/v2.3/includes/languages/english/modules/payment/mercadopago.php
@@ -32,5 +32,6 @@ define('MP_ACTIVATION_METHODS_COUNTRY', 'Payment Methods not accepted');
 define('MB_ACTIVATION_ACTIVATE_METHODS_TEXT', 'Check only the payment methods that you <b>DO NOT</b> want to accept');
 
 define('MP_CHECKOUT_METHOD_TEXT_DESCRIPTION','Accepted payment methods');
+define('MP_CHECKOUT_TEXT_DESCRIPTION','Continue paying with MercadoPago');
 
 ?>

--- a/v2.3/includes/languages/english/modules/payment/mercadopago.php
+++ b/v2.3/includes/languages/english/modules/payment/mercadopago.php
@@ -8,28 +8,29 @@
   Released under the GNU General Public License
 */
 
-/*
-  These constants will be used to show informations at:
-  Admin > Modules > Payment > MercadoPago
-
-  @author cadu (dot) rcorrea (at) gmail (dot) com
-*/
-
-define('MP_ADMIN_CREDENTIALS_SELECTION', 'For credentials, please visit:');
-define('MP_ADMIN_ENABLE', 'Enable MercadoPago module');
-
-
 define('MODULE_PAYMENT_MERCADOPAGO_TEXT_TITLE', 'MercadoPago');
-define('MODULE_PAYMENT_MERCADOPAGO_TEXT_DESCRIPTION', MP_ADMIN_CREDENTIALS_SELECTION . ' <a href=\"https://www.mercadopago.com/mlb/ferramentas/aplicacoes\" target=\"_blank\" ><b>BRA</b></a>|<a href=\"https://www.mercadopago.com/mla/herramientas/aplicaciones\" target=\"_blank\"><b>ARG</b></a>|<a href=\"https://www.mercadopago.com/mlm/herramientas/aplicaciones\" target=\"_blank\" ><b>MEX</b></a>|<a href=\"https://www.mercadopago.com/mlv/herramientas/aplicaciones\" target=\"_blank\"><b>VEN</b></a>');
+define('MODULE_PAYMENT_MERCADOPAGO_TEXT_DESCRIPTION', 
+        '<strong>MercadoPago</strong><br/>
+  	  MercadoPago module for osCommerce. More info at 
+          <a href="https://www.mercadopago.com.ar/developers/en/tools/modules/oscommerce/" style="text-decoration: underline;" target="_blank">MercadoPago Developers</a>.<br />
+  	  <br />
+          <strong>Requirements</strong><br />
+          For credentials (Client Id & Client Secret), please visit:<br />
+          <ul>
+          <li><a href=\"https://www.mercadopago.com/mlb/ferramentas/aplicacoes\" target=\"_blank\" ><b>Brazil</b></a></li>
+          <li><a href=\"https://www.mercadopago.com/mla/herramientas/aplicaciones\" target=\"_blank\"><b>Argentina</b></a></li>
+          <li><a href=\"https://www.mercadopago.com/mlm/herramientas/aplicaciones\" target=\"_blank\" ><b>Mexico</b></a></li>
+          <li><a href=\"https://www.mercadopago.com/mlv/herramientas/aplicaciones\" target=\"_blank\"><b>Venenzuela</b></a></li>
+          </ul>'
+        );
+
 define('MP_ACTIVATION_TITLE', 'Setup MercadoPago');
 define('MP_ACTIVATION_ACTIVATE_COUNTRY', 'Location');
 define('MB_ACTIVATION_ACTIVATE_COUNTRY_TEXT', 'Select your country');
 define('MB_ACTIVATION_CONTINUE_BUTTON', 'Continue');
 define('MP_ACTIVATION_METHODS_COUNTRY', 'Payment Methods not accepted');
 define('MB_ACTIVATION_ACTIVATE_METHODS_TEXT', 'Check only the payment methods that you <b>DO NOT</b> want to accept');
-define('MP_ACTIVATION_TITLE', 'MercadoPago');
-define('MODULE_PAYMENT_MERCADOPAGO_TEXT_DESCRIPTION', '');
 
-
+define('MP_CHECKOUT_METHOD_TEXT_DESCRIPTION','Accepted payment methods');
 
 ?>

--- a/v2.3/includes/languages/portugues/modules/payment/mercadopago.php
+++ b/v2.3/includes/languages/portugues/modules/payment/mercadopago.php
@@ -32,5 +32,6 @@ define('MP_ACTIVATION_METHODS_COUNTRY', 'Formas de pagamento não desejadas');
 define('MB_ACTIVATION_ACTIVATE_METHODS_TEXT', 'Marque apenas as formas de pagamento que você <b>não</b> deseja aceitar');
 
 define('MP_CHECKOUT_METHOD_TEXT_DESCRIPTION','Modos de pagamento aceitos');
+define('MP_CHECKOUT_TEXT_DESCRIPTION','Continue pagando com MercadoPago');
 
 ?>

--- a/v2.3/includes/languages/portugues/modules/payment/mercadopago.php
+++ b/v2.3/includes/languages/portugues/modules/payment/mercadopago.php
@@ -9,25 +9,28 @@
 */
 
 define('MODULE_PAYMENT_MERCADOPAGO_TEXT_TITLE', 'MercadoPago');
-define('MODULE_PAYMENT_MERCADOPAGO_TEXT_DESCRIPTION', 'Para obter os valores Client Id e Client Secret, acesse: <a href=\"https://www.mercadopago.com/mlb/ferramentas/aplicacoes\" target=\"_blank\" ><b>BRA</b></a>|<a href=\"https://www.mercadopago.com/mla/herramientas/aplicaciones\" target=\"_blank\"><b>ARG</b></a>|<a href=\"https://www.mercadopago.com/mlm/herramientas/aplicaciones\" target=\"_blank\" ><b>MEX</b></a>|<a href=\"https://www.mercadopago.com/mlv/herramientas/aplicaciones\" target=\"_blank\"><b>VEN</b></a>');
+define('MODULE_PAYMENT_MERCADOPAGO_TEXT_DESCRIPTION', 
+        '<strong>MercadoPago</strong><br/>
+  	  Módulo MercadoPago para osCommerce. Para mais informações visite 
+          <a href="https://www.mercadopago.com.br/developers/pt/tools/modules/oscommerce/" style="text-decoration: underline;" target="_blank">MercadoPago Developers</a>.<br />
+  	  <br />
+          <strong>Requisitos</strong><br />
+          Para obter credenciais (Client Id e Client Secret), acesse:<br />
+          <ul>
+          <li><a href=\"https://www.mercadopago.com/mlb/ferramentas/aplicacoes\" target=\"_blank\" ><b>Brasil</b></a></li>
+          <li><a href=\"https://www.mercadopago.com/mla/herramientas/aplicaciones\" target=\"_blank\"><b>Argentina</b></a></li>
+          <li><a href=\"https://www.mercadopago.com/mlm/herramientas/aplicaciones\" target=\"_blank\" ><b>México</b></a></li>
+          <li><a href=\"https://www.mercadopago.com/mlv/herramientas/aplicaciones\" target=\"_blank\"><b>Venenzuela</b></a></li>
+          </ul>'
+        );
+
 define('MP_ACTIVATION_TITLE', 'Configurar MercadoPago');
-define('MP_ACTIVATION_TITLE', 'MercadoPago');
-define('MODULE_PAYMENT_MERCADOPAGO_TEXT_DESCRIPTION', 'Seu meio de pagamento na Internet');
 define('MP_ACTIVATION_ACTIVATE_COUNTRY', 'Localização');
 define('MB_ACTIVATION_ACTIVATE_COUNTRY_TEXT', 'Selecione seu país');
 define('MB_ACTIVATION_CONTINUE_BUTTON', 'Continuar');
 define('MP_ACTIVATION_METHODS_COUNTRY', 'Formas de pagamento não desejadas');
-define('MB_ACTIVATION_ACTIVATE_METHODS_TEXT', 'Marque apenas as formas de pagamento que você não deseja aceitar');
+define('MB_ACTIVATION_ACTIVATE_METHODS_TEXT', 'Marque apenas as formas de pagamento que você <b>não</b> deseja aceitar');
 
-/*
-  These constants will be used to show informations at:
-  Admin > Modules > Payment > MercadoPago
-
-  @author cadu (dot) rcorrea (at) gmail (dot) com
-*/
-
-define('MP_ADMIN_CREDENTIALS_SELECTION', 'Para obter as credenciais, acesse:');
-define('MP_ADMIN_ENABLE', 'Habilitar módulo MercadoPago');
-
+define('MP_CHECKOUT_METHOD_TEXT_DESCRIPTION','Modos de pagamento aceitos');
 
 ?>

--- a/v2.3/includes/languages/portugues/modules/payment/mercadopago.php
+++ b/v2.3/includes/languages/portugues/modules/payment/mercadopago.php
@@ -33,5 +33,7 @@ define('MB_ACTIVATION_ACTIVATE_METHODS_TEXT', 'Marque apenas as formas de pagame
 
 define('MP_CHECKOUT_METHOD_TEXT_DESCRIPTION','Modos de pagamento aceitos');
 define('MP_CHECKOUT_TEXT_DESCRIPTION','Continue pagando com MercadoPago');
+define('MP_CHECKOUT_ERROR','Error to get preference key, please contact the store owner');
+
 
 ?>

--- a/v2.3/includes/languages/spanish/modules/payment/mercadopago.php
+++ b/v2.3/includes/languages/spanish/modules/payment/mercadopago.php
@@ -9,13 +9,28 @@
 */
 
 define('MODULE_PAYMENT_MERCADOPAGO_TEXT_TITLE', 'MercadoPago');
-define('MODULE_PAYMENT_MERCADOPAGO_TEXT_DESCRIPTION', 'Para obtener los valores de Client Id y el Client Secret, siga: <a href=\"https://www.mercadopago.com/mlb/ferramentas/aplicacoes\" target=\"_blank\" ><b>BRA</b></a>|<a href=\"https://www.mercadopago.com/mla/herramientas/aplicaciones\" target=\"_blank\"><b>ARG</b></a>|<a href=\"https://www.mercadopago.com/mlm/herramientas/aplicaciones\" target=\"_blank\" ><b>MEX</b></a>|<a href=\"https://www.mercadopago.com/mlv/herramientas/aplicaciones\" target=\"_blank\"><b>VEN</b></a>');
+define('MODULE_PAYMENT_MERCADOPAGO_TEXT_DESCRIPTION', 
+        '<strong>MercadoPago</strong><br/>
+  	  Módulo de MercadoPago para osCommerce, para mas información visite 
+          <a href="https://www.mercadopago.com.ar/developers/es/tools/modules/oscommerce/" style="text-decoration: underline;" target="_blank">MercadoPago Developers</a>.<br />
+  	  <br />
+          <strong>Requerimientos</strong><br />
+          Para obtener las credenciales (Client Id y Client Secret), visite:<br />
+          <ul>
+          <li><a href=\"https://www.mercadopago.com/mlb/ferramentas/aplicacoes\" target=\"_blank\" ><b>Brasil</b></a></li>
+          <li><a href=\"https://www.mercadopago.com/mla/herramientas/aplicaciones\" target=\"_blank\"><b>Argentina</b></a></li>
+          <li><a href=\"https://www.mercadopago.com/mlm/herramientas/aplicaciones\" target=\"_blank\" ><b>México</b></a></li>
+          <li><a href=\"https://www.mercadopago.com/mlv/herramientas/aplicaciones\" target=\"_blank\"><b>Venenzuela</b></a></li>
+          </ul>'
+        );
+
 define('MP_ACTIVATION_TITLE', 'Configurar MercadoPago');
-define('MP_ACTIVATION_TITLE', 'MercadoPago');
-define('MODULE_PAYMENT_MERCADOPAGO_TEXT_DESCRIPTION', '');
 define('MP_ACTIVATION_ACTIVATE_COUNTRY', 'País');
 define('MB_ACTIVATION_ACTIVATE_COUNTRY_TEXT', 'Seleccione su país');
 define('MB_ACTIVATION_CONTINUE_BUTTON', 'Continuar');
 define('MP_ACTIVATION_METHODS_COUNTRY', 'Medios de pago no deseados');
-define('MB_ACTIVATION_ACTIVATE_METHODS_TEXT', 'Formas de pago que NO quiere aceptar');
+define('MB_ACTIVATION_ACTIVATE_METHODS_TEXT', 'Seleccione solo las formas de pago que <b>NO</b> quiere aceptar');
+
+define('MP_CHECKOUT_METHOD_TEXT_DESCRIPTION','Medios de pago aceptados');
+
 ?>

--- a/v2.3/includes/languages/spanish/modules/payment/mercadopago.php
+++ b/v2.3/includes/languages/spanish/modules/payment/mercadopago.php
@@ -32,5 +32,6 @@ define('MP_ACTIVATION_METHODS_COUNTRY', 'Medios de pago no deseados');
 define('MB_ACTIVATION_ACTIVATE_METHODS_TEXT', 'Seleccione solo las formas de pago que <b>NO</b> quiere aceptar');
 
 define('MP_CHECKOUT_METHOD_TEXT_DESCRIPTION','Medios de pago aceptados');
+define('MP_CHECKOUT_TEXT_DESCRIPTION','Continue pagando con MercadoPago');
 
 ?>

--- a/v2.3/includes/languages/spanish/modules/payment/mercadopago.php
+++ b/v2.3/includes/languages/spanish/modules/payment/mercadopago.php
@@ -33,5 +33,6 @@ define('MB_ACTIVATION_ACTIVATE_METHODS_TEXT', 'Seleccione solo las formas de pag
 
 define('MP_CHECKOUT_METHOD_TEXT_DESCRIPTION','Medios de pago aceptados');
 define('MP_CHECKOUT_TEXT_DESCRIPTION','Continue pagando con MercadoPago');
+define('MP_CHECKOUT_ERROR','No se pueden obtener los datos de MercadoPago, por favor contáctese con los administradores del sitio.');
 
 ?>

--- a/v2.3/includes/modules/payment/mercadopago.php
+++ b/v2.3/includes/modules/payment/mercadopago.php
@@ -389,7 +389,7 @@ class mercadopago {
         $this->description = MODULE_PAYMENT_MERCADOPAGO_TEXT_DESCRIPTION;
         $this->sort_order = MODULE_PAYMENT_MERCADOPAGO_SORT_ORDER;
 
-        $this->enabled = ((MODULE_PAYMENT_MERCADOPAGO_STATUS == 'Verdadeiro') ? true : false);
+        $this->enabled = ((MODULE_PAYMENT_MERCADOPAGO_STATUS == 'true') ? true : false);
 
 
         if ((int) MODULE_PAYMENT_MERCADOPAGO_ORDER_STATUS_ID > 0) {
@@ -456,24 +456,36 @@ class mercadopago {
         return false;
     }
 
-    /* function selection() {
-      return array('id' => $this->code,
-      'module' => $this->title);
-      } */
-
-//una version mejorada de 29/06
     function selection() {
-        $mercadopago_image = "http://imgmp.mlstatic.com/org-img/MLB/MP/BANNERS/tipo2_575X40.jpg";
         $fields = array();
-        $fields[] = array('title' => 'Modos de pagamento aceitos:',
+        $fields[] = array('title' => MP_CHECKOUT_METHOD_TEXT_DESCRIPTION . ':',
             'text' => '');
-        $fields[] = array('title' => '<img src="' . $mercadopago_image . '">',
+        $fields[] = array('title' => '<img src="' . $this->get_mercadopago_methods_image() . '" title="MercadoPago - Medios de pago" alt="MercadoPago - Medios de pago" width="575" height="40" >',
             'text' => '');
         return array('id' => $this->code,
             'module' => $this->title,
             'fields' => $fields);
     }
 
+    function get_mercadopago_methods_image() {
+        switch (MODULE_PAYMENT_MERCADOPAGO_COUNTRY):
+            case 'MLB':
+                $mercadopago_image = "http://imgmp.mlstatic.com/org-img/MLB/MP/BANNERS/tipo2_575X40.jpg";
+                break;
+            case 'MLA':
+                $mercadopago_image = "http://imgmp.mlstatic.com/org-img/banners/ar/medios/575X40.jpg";
+                break;
+            case 'MLM':
+                $mercadopago_image = "http://imgmp.mlstatic.com/org-img/banners/mx/medios/MLM_575X40.JPG";
+                break;
+             case 'MLV':
+                $mercadopago_image = "http://imgmp.mlstatic.com/org-img/banners/ve/medios/575X40.jpg";
+                break;
+        endswitch;
+         
+        return $mercadopago_image;
+    }
+    
     function pre_confirmation_check() {
         return false;
     }
@@ -568,9 +580,9 @@ class mercadopago {
         return $methods;
     }
 
-    public function GetCategories() {
+    public function GetCategories($country_id = null) {
         $mp = new MPShop();
-        $url = "https://api.mercadolibre.com/item_categories";
+        $url = "https://api.mercadolibre.com/sites/" . $country_id . "/categories";
         $header = array('Accept: application/json');
         $categories = $mp->DoPost(null, $url, $header, '200', 'none', 'get');
         return $categories;
@@ -624,10 +636,10 @@ class mercadopago {
 
         $country = $_POST['country'];
 
-        tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable MercadoPago module', 'MODULE_PAYMENT_MERCADOPAGO_STATUS', 'Verdadeiro', 'Deseja aceitar pagamentos por meio do MercadoPago?', '6', '3', 'tep_cfg_select_option(array(\'Verdadeiro\', \'Falso\'), ', now())");
-        tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_description, configuration_group_id, sort_order, date_added) values ('Client_id','MODULE_PAYMENT_MERCADOPAGO_CLIENTID','Insert your client id', '6','1',now())");
-        tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_description, configuration_group_id, sort_order, date_added) values ('Client_secret','MODULE_PAYMENT_MERCADOPAGO_CLIENTSECRET','Insert your client secret','6','2', now())");
-        tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Ordem de exibi&ccedil;&atilde;o', 'MODULE_PAYMENT_MERCADOPAGO_SORT_ORDER', '1', 'O mais baixo &eacute; exibido primeiro.', '6', '0', now())");
+        tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, set_function, date_added) values ('Enable MercadoPago module', 'MODULE_PAYMENT_MERCADOPAGO_STATUS', 'true', 'Do you want to accept MercadoPago payments?', '6', '3', 'tep_cfg_select_option(array(\'true\', \'false\'), ', now())");
+        tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_description, configuration_group_id, sort_order, date_added) values ('Client_id','MODULE_PAYMENT_MERCADOPAGO_CLIENTID','Insert your Client ID', '6','1',now())");
+        tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_description, configuration_group_id, sort_order, date_added) values ('Client_secret','MODULE_PAYMENT_MERCADOPAGO_CLIENTSECRET','Insert your Client Secret','6','2', now())");
+        tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_value, configuration_description, configuration_group_id, sort_order, date_added) values ('Sort order of display.', 'MODULE_PAYMENT_MERCADOPAGO_SORT_ORDER', '1', 'Sort order of display. Lowest is displayed first.', '6', '0', now())");
         tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_description, configuration_group_id, sort_order, configuration_value, date_added) values ('Country','MODULE_PAYMENT_MERCADOPAGO_COUNTRY','Recomended to remove and install the module again if you need to change the country', '6','3','" . $country . "',now())");
         tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_description, configuration_group_id, sort_order, configuration_value, date_added) values ('Exclude Methods','MODULE_PAYMENT_MERCADOPAGO_METHODS','Recomended to remove and install the module again if you need to change the no accepted methods', '6','3','" . $posts['methods'] . "',now())");
         tep_db_query("insert into " . TABLE_CONFIGURATION . " (configuration_title, configuration_key, configuration_description, configuration_group_id, sort_order, configuration_value, date_added) values ('Categories','MODULE_PAYMENT_MERCADOPAGO_CATEGORIES','Recomended to remove and install the module again if you need to change categories', '6','3','" . $categories . "',now())");

--- a/v2.3/mercadopago.php
+++ b/v2.3/mercadopago.php
@@ -78,7 +78,7 @@ $mp = new mercadopago();
 
   } else {
    
-   echo 'Error to get preference key, please contact the store owner'; 
+   echo MP_CHECKOUT_ERROR; 
   
   }
  

--- a/v2.3/mercadopago.php
+++ b/v2.3/mercadopago.php
@@ -3,6 +3,9 @@
 require('includes/application_top.php');
 require(DIR_WS_INCLUDES . 'template_top.php');
 require('includes/modules/payment/mercadopago.php');
+require(DIR_WS_LANGUAGES . $language . '/modules/payment/mercadopago.php');
+
+$mp = new mercadopago();
 
   if ($_REQUEST['bt'] != '') { 
 
@@ -37,16 +40,13 @@ require('includes/modules/payment/mercadopago.php');
           <h1>Mercado Pago</h1>
 
           <div class="botao">
-          <?php if(MODULE_PAYMENT_MERCADOPAGO_COUNTRY == 'MLB'){ ?>
-          <div class="left" style="position:relative;float:left;"/><h3 style="margin: 10px;">Continue pagando com MercadoPago</h3></div>
-          <?php } else { ?>
-          <div class="left"/><h3 style="margin: 10px;">Continue pagando con MercadoPago</h3></div>
-          <?php } ?>
-          <div class="right" style="position:relative;float:right;" />
-          <a href="<?php echo $_REQUEST['bt']; ?>" id="btnPagar" name="MP-Checkout" class="blue-l-rn-ar" mp-mode="<?php echo $mode; ?>">Comprar</a>
+            <div class="left">
+              <h3 style="margin: 10px;"><?= MP_CHECKOUT_TEXT_DESCRIPTION ?></h3>
+              <img src="<?= $mp->get_mercadopago_methods_image() ?>" alt="MercadoPago" title="MercadoPago" style="margin: 10px;"/>
+              <a href="<?php echo $_REQUEST['bt']; ?>" id="btnPagar" name="MP-Checkout" class="blue-l-rn-ar" mp-mode="<?php echo $mode; ?>">Comprar</a>
+            </div>
           </div>
-          </div>
-          <img src="http://imgmp.mlstatic.com/org-img/MLB/MP/BANNERS/tipo2_468X60.jpg" alt="MercadoPago" title="MercadoPago" />
+          <!-- http://imgmp.mlstatic.com/org-img/MLB/MP/BANNERS/tipo2_468X60.jpg -->
 
           <script type="text/javascript">
               (function(){function $MPBR_load(){window.$MPBR_loaded !== true && (function(){var s = document.createElement("script");s.type = "text/javascript";s.async = true;
@@ -88,8 +88,7 @@ require('includes/modules/payment/mercadopago.php');
 
   if(!isset($_REQUEST['bt']) && isset($_REQUEST['id']) && isset($_REQUEST['topic']) && $_REQUEST['topic'] = 'payment'){
 
-    $mb = new mercadopago();
-    $status = $mb->retorno($_REQUEST['id']);
+    $status = $mp->retorno($_REQUEST['id']);
 
   }
 


### PR DESCRIPTION
Added English, Portuguese and Spanish translations to:
- Module Activation Steps
- Checkout process
- Error messages
Now the MercadoPago banners loads dynamically from MercadoPago site, for all the supported countries.
On the module activation process, the list of categories respond to the previous selected country.

-- Sorry for bad English